### PR TITLE
[bugfix] Initialize initial reference timeval

### DIFF
--- a/base/pcap-snoop.c
+++ b/base/pcap-snoop.c
@@ -91,8 +91,8 @@ int packet_cnt = 0;  // Packet counter used for connection pool cleaning
 int conn_freq = 100; // Number of packets after which a connection pool
                      // cleaning is performed
 int conn_ttl = 100;  // TTL of inactive connections in connection pool
-struct timeval last_packet_seen_time; // Timestamp of the last packet of the
-                                      // last block of conn_freq packets seen
+struct timeval last_packet_seen_time = // Timestamp of the last packet of the
+    (struct timeval) {0};              // last block of conn_freq packets seen
 
 int err_exit(str,num)
   char *str;

--- a/base/tcpconn.c
+++ b/base/tcpconn.c
@@ -172,6 +172,9 @@ int clean_old_conn() {
     struct timeval dt;
     int i = 0;
 
+    if(!last_packet_seen_time.tv_sec)
+        return 0; // Still processing first block of packets
+
     for(conn=first_conn;conn;conn=conn->next) {
         i++;
         tcpconn = &conn->conn;


### PR DESCRIPTION
Avoids wrong cleaning of first connection(s)