### PR TITLE
Fix a null pointer dereference bug

### DIFF
--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -68,7 +68,7 @@ static char *RCSSTRING="$Id: ssldecode.c,v 1.9 2002/08/17 01:33:17 ekr Exp $";
 
 static char *ssl_password;
 
-extern char *digests;
+extern char *digests[];
 extern UINT4 SSL_print_flags;
 
 struct ssl_decode_ctx_ {


### PR DESCRIPTION
Fix a null pointer dereference bug of tls12_prf be caused by invalid extern declaration for digests variable.