### PR TITLE
Fix packet length calculation if IP length is 0, due to TSO

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -15,6 +15,7 @@ Richard Levitte
 Hugh Mandeville
 Eric Murray
 Henrik Nordstrom
+Alper Akcan
 
 If you think you should be on this list, send me mail at <ekr@rtfm.com>.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Mon 29 May 2017 03:49:00 PM +03 Alper <alper.akcan@gmail.com>
+	* Fix packet length calculation if IP length is
+	  0 due to TSO.
+
 Wed Aug 21 10:48:45 2002 EKR <ekr@rtfm.com>
         * Installed Greg Stark's new Win32 patches.
 

--- a/base/network.c
+++ b/base/network.c
@@ -133,8 +133,12 @@ int network_process_packet(handler,timestamp,data,length)
 
     hlen=p.ip->ip_hl * 4;
     p.data += hlen;
-    p.len =ntohs(p.ip->ip_len)-hlen;
-    
+    p.len = ntohs(p.ip->ip_len);
+    if (p.len == 0) {
+        DBG((0,"ip length reported as 0, presumed to be because of 'TCP segmentation offload' (TSO)\n"));
+        p.len = p._len;
+    }
+    p.len -= hlen;
     
     switch(p.ip->ip_p){
       case IPPROTO_TCP:


### PR DESCRIPTION
can not parse tcp packets and decode application data due to miscalculation of packet length.