### PR TITLE
Fix a typo in the man page

### DIFF
--- a/ssldump.1
+++ b/ssldump.1
@@ -437,7 +437,7 @@ To listen to traffic to the server \fIromeo\fP on port \fI443\fP.
 .fi
 .RE
 .LP
-To decrypt traffic to to host \fIromeo\fR 
+To decrypt traffic to host \fIromeo\fR 
 \fIserver.pem\fR and the password \fIfoobar\fR
 .RS
 .nf


### PR DESCRIPTION
Delete the extra "to" in "To decrypt traffic to to host" under the examples section.