### PR TITLE
Tls extensions

### DIFF
--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -2479,10 +2479,15 @@ static int decode_extension_extended_master_secret(ssl,dir,seg,data)
   segment *seg;
   Data *data;
   {
-    int l,r;
+    int l,r,*ems;
+
+    ems=&ssl->decoder->extended_master_secret;
+
     SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
     data->len-=l;
     data->data+=l;
+
+    *ems=dir==DIR_I2R?1:*ems==1;
     return(0);
   }
 static int decode_extension(ssl,dir,seg,data)

--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -184,7 +184,7 @@ static int decode_HandshakeType_ClientHello(ssl,dir,seg,data)
     extern decoder extension_decoder[];
 	
     printf("\n");
-    ssl_update_session_hash(ssl,data);
+    ssl_update_handshake_messages(ssl,data);
     SSL_DECODE_UINT8(ssl,0,0,data,&vj);
     SSL_DECODE_UINT8(ssl,0,0,data,&vn);    
 
@@ -263,7 +263,7 @@ static int decode_HandshakeType_ServerHello(ssl,dir,seg,data)
     extern decoder extension_decoder[];
 
     printf("\n");
-    ssl_update_session_hash(ssl,data);
+    ssl_update_handshake_messages(ssl,data);
     SSL_DECODE_UINT8(ssl,0,0,data,&vj);
     SSL_DECODE_UINT8(ssl,0,0,data,&vn);    
 
@@ -324,7 +324,7 @@ static int decode_HandshakeType_Certificate(ssl,dir,seg,data)
     int r;
   
     printf("\n");
-    ssl_update_session_hash(ssl,data);
+    ssl_update_handshake_messages(ssl,data);
     SSL_DECODE_UINT24(ssl,"certificates len",0,data,&len);
 
     while(len){
@@ -348,7 +348,7 @@ static int decode_HandshakeType_ServerKeyExchange(ssl,dir,seg,data)
    int r;
 
     printf("\n");			      
-    ssl_update_session_hash(ssl,data);
+    ssl_update_handshake_messages(ssl,data);
    if(ssl->cs){
      P_(P_ND){
 	explain(ssl,"params\n");
@@ -386,7 +386,7 @@ static int decode_HandshakeType_CertificateRequest(ssl,dir,seg,data)
     int r;
     
     printf("\n");
-    ssl_update_session_hash(ssl,data);
+    ssl_update_handshake_messages(ssl,data);
     SSL_DECODE_UINT8(ssl,"certificate_types len",0,data,&len);
     for(;len;len--){
       SSL_DECODE_ENUM(ssl,"certificate_types",1,
@@ -418,7 +418,7 @@ static int decode_HandshakeType_ServerHelloDone(ssl,dir,seg,data)
 
 
   printf("\n");
-  ssl_update_session_hash(ssl,data);
+  ssl_update_handshake_messages(ssl,data);
   return(0);
 
   }
@@ -432,7 +432,7 @@ static int decode_HandshakeType_CertificateVerify(ssl,dir,seg,data)
 
   int r;
   printf("\n");
-  ssl_update_session_hash(ssl,data);
+  ssl_update_handshake_messages(ssl,data);
   SSL_DECODE_OPAQUE_ARRAY(ssl,"Signature",-(1<<15-1),P_HL,data,0);
   return(0);
 
@@ -449,7 +449,7 @@ static int decode_HandshakeType_ClientKeyExchange(ssl,dir,seg,data)
    Data pms;
 	
     printf("\n");
-    ssl_update_session_hash(ssl,data);
+    ssl_update_handshake_messages(ssl,data);
    if(ssl->cs){
      switch(ssl->cs->kex){
 
@@ -2461,90 +2461,6 @@ static int decode_extension_server_name(ssl,dir,seg,data)
     data->data+=l;
     return(0);
   }
-static int decode_extension_max_fragment_length(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
-static int decode_extension_client_certificate_url(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
-static int decode_extension_trusted_ca_keys(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
-static int decode_extension_truncated_hmac(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
-static int decode_extension_status_request(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
-static int decode_extension_signature_algorithms(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
-static int decode_extension_application_layer_protocol_negotiation(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
 static int decode_extension_encrypt_then_mac(ssl,dir,seg,data)
   ssl_obj *ssl;
   int dir;
@@ -2558,18 +2474,6 @@ static int decode_extension_encrypt_then_mac(ssl,dir,seg,data)
     return(0);
   }
 static int decode_extension_extended_master_secret(ssl,dir,seg,data)
-  ssl_obj *ssl;
-  int dir;
-  segment *seg;
-  Data *data;
-  {
-    int l,r;
-    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
-    data->len-=l;
-    data->data+=l;
-    return(0);
-  }
-static int decode_extension_next_protocol_negotiation(ssl,dir,seg,data)
   ssl_obj *ssl;
   int dir;
   segment *seg;
@@ -2604,37 +2508,37 @@ decoder extension_decoder[] = {
 	{
 		1,
 		"max_fragment_length",
-		decode_extension_max_fragment_length
+		decode_extension
 	},
 	{
 		2,
 		"client_certificate_url",
-		decode_extension_client_certificate_url
+		decode_extension
 	},
 	{
 		3,
 		"trusted_ca_keys",
-		decode_extension_trusted_ca_keys
+		decode_extension
 	},
 	{
 		4,
 		"truncated_hmac",
-		decode_extension_truncated_hmac
+		decode_extension
 	},
 	{
 		5,
 		"status_request",
-		decode_extension_status_request
+		decode_extension
 	},
 	{
 		13,
 		"signature_algorithms",
-		decode_extension_signature_algorithms
+		decode_extension
 	},
 	{
 		16,
 		"application_layer_protocol_negotiation",
-		decode_extension_application_layer_protocol_negotiation
+		decode_extension
 	},
 	{
 		22,
@@ -2649,7 +2553,7 @@ decoder extension_decoder[] = {
 	{
 		13172,
 		"next_protocol_negotiation",
-		decode_extension_next_protocol_negotiation
+		decode_extension
 	},
 
 {-1}

--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -2467,10 +2467,15 @@ static int decode_extension_encrypt_then_mac(ssl,dir,seg,data)
   segment *seg;
   Data *data;
   {
-    int l,r;
+    int l,r,*etm;
+
+    etm=&ssl->extensions->encrypt_then_mac;
+
     SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
     data->len-=l;
     data->data+=l;
+
+    *etm=dir==DIR_I2R?1:*etm==1;
     return(0);
   }
 static int decode_extension_extended_master_secret(ssl,dir,seg,data)
@@ -2508,7 +2513,7 @@ decoder extension_decoder[] = {
 	{
 		0,
 		"server_name",
-		decode_extension_server_name
+		decode_extension,
 	},
 	{
 		1,

--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -231,7 +231,6 @@ static int decode_HandshakeType_ClientHello(ssl,dir,seg,data)
       }
     }
 
-    /* TODO: add code to print Extensions */
     SSL_DECODE_UINT16(ssl,"extensions len",0,data,&exlen);
     if (exlen) {
       explain(ssl , "extensions\n");
@@ -292,7 +291,6 @@ static int decode_HandshakeType_ServerHello(ssl,dir,seg,data)
     SSL_DECODE_ENUM(ssl,"compressionMethod",1,compression_method_decoder,P_HL,data,0);
     P_(P_HL) printf("\n");
 
-    /* TODO: add code to print Extensions */
     SSL_DECODE_UINT16(ssl,"extensions len",0,data,&exlen);
     if (exlen) {
       explain(ssl , "extensions\n");

--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -174,12 +174,13 @@ static int decode_HandshakeType_ClientHello(ssl,dir,seg,data)
   {
 
 
-    UINT4 vj,vn,cs,cslen,complen,comp,odd;
+    UINT4 vj,vn,cs,cslen,complen,comp,odd,exlen,ex;
     Data session_id,random;
     int r;
 
     extern decoder cipher_suite_decoder[];
-    extern decoder compression_method_decoder[];    
+    extern decoder compression_method_decoder[];
+    extern decoder extension_decoder[];
 	
     printf("\n");			    
     SSL_DECODE_UINT8(ssl,0,0,data,&vj);
@@ -224,6 +225,22 @@ static int decode_HandshakeType_ClientHello(ssl,dir,seg,data)
       for(;complen;complen--){
         SSL_DECODE_ENUM(ssl,0,1,compression_method_decoder,P_HL,data,&comp);
         printf("\n");
+      }
+    }
+
+    /* TODO: add code to print Extensions */
+    SSL_DECODE_UINT16(ssl,"extensions len",0,data,&exlen);
+    if (exlen) {
+      explain(ssl , "extensions\n");
+      while(data->len) {
+	SSL_DECODE_UINT16(ssl, "extension type", 0, data, &ex);
+	if (ssl_decode_switch(ssl,extension_decoder,ex,dir,seg,data) == R_NOT_FOUND) {
+	  P_(P_RH){
+	    explain(ssl, "Extension type: %s not yet implemented in ssldump", ex);
+	  }
+	  continue;
+	}
+	printf("\n");
       }
     }
     return(0);
@@ -2403,3 +2420,195 @@ decoder client_certificate_type_decoder[]={
 {-1}
 };
 
+static int decode_extension_server_name(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_max_fragment_length(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_client_certificate_url(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_trusted_ca_keys(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_truncated_hmac(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_status_request(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_signature_algorithms(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_application_layer_protocol_negotiation(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_encrypt_then_mac(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_extended_master_secret(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+static int decode_extension_next_protocol_negotiation(ssl,dir,seg,data)
+  ssl_obj *ssl;
+  int dir;
+  segment *seg;
+  Data *data;
+  {
+    int l,r;
+    SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
+    data->len-=l;
+    data->data+=l;
+    return(0);
+  }
+
+decoder extension_decoder[] = {
+	{
+		0,
+		"server_name",
+		decode_extension_server_name
+	},
+	{
+		1,
+		"max_fragment_length",
+		decode_extension_max_fragment_length
+	},
+	{
+		2,
+		"client_certificate_url",
+		decode_extension_client_certificate_url
+	},
+	{
+		3,
+		"trusted_ca_keys",
+		decode_extension_trusted_ca_keys
+	},
+	{
+		4,
+		"truncated_hmac",
+		decode_extension_truncated_hmac
+	},
+	{
+		5,
+		"status_request",
+		decode_extension_status_request
+	},
+	{
+		13,
+		"signature_algorithms",
+		decode_extension_signature_algorithms
+	},
+	{
+		16,
+		"application_layer_protocol_negotiation",
+		decode_extension_application_layer_protocol_negotiation
+	},
+	{
+		22,
+		"encrypt_then_mac",
+		decode_extension_encrypt_then_mac
+	},
+	{
+		23,
+		"extended_master_secret",
+		decode_extension_extended_master_secret
+	},
+	{
+		13172,
+		"next_protocol_negotiation",
+		decode_extension_next_protocol_negotiation
+	},
+
+{-1}
+};

--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -2481,7 +2481,7 @@ static int decode_extension_extended_master_secret(ssl,dir,seg,data)
   {
     int l,r,*ems;
 
-    ems=&ssl->decoder->extended_master_secret;
+    ems=&ssl->extensions->extended_master_secret;
 
     SSL_DECODE_UINT16(ssl,"extension length",0,data,&l);
     data->len-=l;

--- a/ssl/ssl_analyze.c
+++ b/ssl/ssl_analyze.c
@@ -265,6 +265,9 @@ static int create_ssl_analyzer(handle,ctx,conn,objp,i_addr,i_port,r_addr,r_port,
 
     if(r=ssl_decoder_create(&obj->decoder,obj->ssl_ctx))
       ABORT(r);
+
+    if (!(obj->extensions=malloc(sizeof(ssl_extensions))))
+      ABORT(R_NO_MEMORY);
     
     *objp=(proto_obj *)obj;
 
@@ -291,7 +294,8 @@ static int destroy_ssl_analyzer(objp)
     free_r_queue(obj->r2i_queue);
     ssl_decoder_destroy(&obj->decoder);
     free(obj->client_name);
-    free(obj->server_name);    
+    free(obj->server_name);
+    free(obj->extensions);
     free(*objp);
     *objp=0;
 

--- a/ssl/ssl_h.h
+++ b/ssl/ssl_h.h
@@ -86,6 +86,7 @@ typedef struct ssl_obj_ {
      struct timeval time_last;
      ssl_decode_ctx *ssl_ctx;
      ssl_decoder *decoder;
+     ssl_extensions extensions;
 
      int process_ciphertext;
 
@@ -106,6 +107,10 @@ typedef struct decoder_ {
      char *name;
      int (*print) PROTO_LIST((ssl_obj *,int direction,segment *seg,Data *data));
 } decoder;
+
+typedef struct ssl_extensions_ {
+  int extended_master_secret;
+} ssl_extensions;
 
 #define SSL_NO_DATA	1
 #define SSL_BAD_CONTENT_TYPE 2

--- a/ssl/ssl_h.h
+++ b/ssl/ssl_h.h
@@ -67,6 +67,10 @@ typedef struct d_queue_ {
      int offset;	/*How far into the first segment this record starts*/
 } r_queue;
 
+typedef struct ssl_extensions_ {
+  int extended_master_secret;
+} ssl_extensions;
+
 typedef struct ssl_obj_ {
      tcp_conn *conn;
      int r_state;
@@ -86,7 +90,7 @@ typedef struct ssl_obj_ {
      struct timeval time_last;
      ssl_decode_ctx *ssl_ctx;
      ssl_decoder *decoder;
-     ssl_extensions extensions;
+     ssl_extensions *extensions;
 
      int process_ciphertext;
 

--- a/ssl/ssl_h.h
+++ b/ssl/ssl_h.h
@@ -68,6 +68,7 @@ typedef struct d_queue_ {
 } r_queue;
 
 typedef struct ssl_extensions_ {
+  int encrypt_then_mac;
   int extended_master_secret;
 } ssl_extensions;
 

--- a/ssl/ssl_h.h
+++ b/ssl/ssl_h.h
@@ -112,10 +112,6 @@ typedef struct decoder_ {
      int (*print) PROTO_LIST((ssl_obj *,int direction,segment *seg,Data *data));
 } decoder;
 
-typedef struct ssl_extensions_ {
-  int extended_master_secret;
-} ssl_extensions;
-
 #define SSL_NO_DATA	1
 #define SSL_BAD_CONTENT_TYPE 2
 #define SSL_BAD_PMS	     3

--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -55,6 +55,7 @@
 #include <openssl/x509v3.h>
 #endif
 #include "ssldecode.h"
+#include "ssl_rec.h"
 #include "r_assoc.h"
 static char *RCSSTRING="$Id: ssldecode.c,v 1.9 2002/08/17 01:33:17 ekr Exp $";
 
@@ -79,6 +80,22 @@ struct ssl_decode_ctx_ {
      char dummy;       /* Some compilers (Win32) don't like empty
                            structs */
 #endif     
+};
+
+struct ssl_decoder_ {
+     ssl_decode_ctx *ctx;
+     Data *session_id;
+     SSL_CipherSuite *cs;
+     Data *client_random;
+     Data *server_random;
+     int ephemeral_rsa;
+     Data *PMS;
+     Data *MS;
+     Data *handshake_messages;
+     ssl_rec_decoder *c_to_s;
+     ssl_rec_decoder *s_to_c;     
+     ssl_rec_decoder *c_to_s_n;
+     ssl_rec_decoder *s_to_c_n;
 };
 
 

--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -55,7 +55,6 @@
 #include <openssl/x509v3.h>
 #endif
 #include "ssldecode.h"
-#include "ssl_rec.h"
 #include "r_assoc.h"
 static char *RCSSTRING="$Id: ssldecode.c,v 1.9 2002/08/17 01:33:17 ekr Exp $";
 
@@ -80,22 +79,6 @@ struct ssl_decode_ctx_ {
      char dummy;       /* Some compilers (Win32) don't like empty
                            structs */
 #endif     
-};
-
-struct ssl_decoder_ {
-     ssl_decode_ctx *ctx;
-     Data *session_id;
-     SSL_CipherSuite *cs;
-     Data *client_random;
-     Data *server_random;
-     int ephemeral_rsa;
-     Data *PMS;
-     Data *MS;
-     Data *handshake_messages;
-     ssl_rec_decoder *c_to_s;
-     ssl_rec_decoder *s_to_c;     
-     ssl_rec_decoder *c_to_s_n;
-     ssl_rec_decoder *s_to_c_n;
 };
 
 

--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -114,7 +114,7 @@ static int ssl3_generate_export_iv PROTO_LIST((ssl_obj *ssl,
 static int ssl_generate_keying_material PROTO_LIST((ssl_obj *ssl,
   ssl_decoder *d));
 static int ssl_generate_session_hash PROTO_LIST((ssl_obj *ssl,
-						 ssl_decoder *d));
+  ssl_decoder *d));
 #endif
 
 static int ssl_create_session_lookup_key PROTO_LIST((ssl_obj *ssl,
@@ -858,7 +858,9 @@ static int ssl_generate_keying_material(ssl,d)
         ABORT(r);
 
       if (ssl->extensions->extended_master_secret) {
-	ssl_generate_session_hash(ssl,d);
+	if(r=ssl_generate_session_hash(ssl,d))
+	  ABORT(r);
+
 	temp.len=0;
 	if(r=PRF(ssl,d->PMS,"extended master secret",d->session_hash,&temp,
 	  d->MS))

--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -568,7 +568,7 @@ int ssl_process_client_key_exchange(ssl,d,msg,len)
 
 
 
-int ssl_update_session_hash(ssl,data)
+int ssl_update_handshake_messages(ssl,data)
   ssl_obj *ssl;
   Data *data;
   {

--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -92,6 +92,7 @@ struct ssl_decoder_ {
      Data *PMS;
      Data *MS;
      Data *handshake_messages;
+     Data *session_hash;
      ssl_rec_decoder *c_to_s;
      ssl_rec_decoder *s_to_c;     
      ssl_rec_decoder *c_to_s_n;
@@ -112,6 +113,8 @@ static int ssl3_generate_export_iv PROTO_LIST((ssl_obj *ssl,
   Data *rnd1,Data *rnd2,Data *out));
 static int ssl_generate_keying_material PROTO_LIST((ssl_obj *ssl,
   ssl_decoder *d));
+static int ssl_generate_session_hash PROTO_LIST((ssl_obj *ssl,
+						 ssl_decoder *d));
 #endif
 
 static int ssl_create_session_lookup_key PROTO_LIST((ssl_obj *ssl,
@@ -216,6 +219,7 @@ int ssl_decoder_destroy(dp)
     r_data_destroy(&d->PMS);
     r_data_destroy(&d->MS);
     r_data_destroy(&d->handshake_messages);
+    r_data_destroy(&d->session_hash);
     ssl_destroy_rec_decoder(&d->c_to_s);
     ssl_destroy_rec_decoder(&d->c_to_s_n);
     ssl_destroy_rec_decoder(&d->s_to_c);
@@ -384,6 +388,35 @@ int ssl_decode_record(ssl,dec,direction,ct,version,d)
 #endif    
   }
 
+int ssl_update_handshake_messages(ssl,data)
+  ssl_obj *ssl;
+  Data *data;
+  {
+    Data *hms;
+    UCHAR *d;
+    int l,r,_status;
+
+    hms = ssl->decoder->handshake_messages;
+    d = data->data-4;
+    l = data->len+4;
+
+    if(hms){
+      if(!(hms->data = realloc(hms->data,l+hms->len)))
+	ABORT(R_NO_MEMORY);
+
+      memcpy(hms->data+hms->len,d,l);
+      hms->len+=l;
+    }
+    else{
+      if(r=r_data_create(&hms,d,l))
+  	ABORT(r);
+      ssl->decoder->handshake_messages=hms;
+    }
+
+    _status=0;
+  abort:
+    return(_status);
+  }
 
 static int ssl_create_session_lookup_key(ssl,id,idlen,keyp,keyl)
   ssl_obj *ssl;
@@ -566,37 +599,6 @@ int ssl_process_client_key_exchange(ssl,d,msg,len)
     
   }
 
-
-
-int ssl_update_handshake_messages(ssl,data)
-  ssl_obj *ssl;
-  Data *data;
-  {
-    Data *hms;
-    UCHAR *d;
-    int l,r,_status;
-
-    hms = ssl->decoder->handshake_messages;
-    d = data->data-4;
-    l = data->len+4;
-
-    if(hms){
-      if(!(hms->data = realloc(hms->data,l+hms->len)))
-	ABORT(R_NO_MEMORY);
-
-      memcpy(hms->data+hms->len,d,l);
-      hms->len+=l;
-    }
-    else{
-      if(r=r_data_create(&hms,d,l))
-  	ABORT(r);
-      ssl->decoder->handshake_messages=hms;
-    }
-
-    _status=0;
-  abort:
-    return(_status);
-  }
 
 #ifdef OPENSSL
 static int tls_P_hash(ssl,secret,seed,md,out)
@@ -854,10 +856,13 @@ static int ssl_generate_keying_material(ssl,d)
     if(!d->MS){
       if(r=r_data_alloc(&d->MS,48))
         ABORT(r);
-    
-      if(r=PRF(ssl,d->PMS,"master secret",d->client_random,d->server_random,
-        d->MS))
-        ABORT(r);
+
+      if (ssl->extensions->extended_master_secret)
+	ssl_generate_session_hash(ssl,d);
+      else
+	if(r=PRF(ssl,d->PMS,"master secret",d->client_random,d->server_random,
+	  d->MS))
+	  ABORT(r);
 
       CRDUMPD("MS",d->MS);
     }
@@ -992,4 +997,37 @@ static int ssl_generate_keying_material(ssl,d)
     return(_status);
   }
 
+static int ssl_generate_session_hash(ssl,d)
+  ssl_obj *ssl;
+  ssl_decoder *d;
+  /* Data **sh; */
+  {
+    UCHAR *out[32];
+    int dgi;
+    unsigned int len;
+    const EVP_MD *md;
+    EVP_MD_CTX dgictx;
+
+    switch(ssl->version){
+    case TLSV12_VERSION:
+      dgi = MAX(DIG_SHA256, ssl->cs->dig)-0x40;
+      if ((md=EVP_get_digestbyname(digests[dgi])) == NULL) {
+	DBG((0,"Cannot get EVP for digest %s, openssl library current?",
+	     digests[dgi]));
+	ERETURN(SSL_BAD_MAC);
+      }
+      break;
+      case SSLV3_VERSION:
+      case TLSV1_VERSION:
+      case TLSV11_VERSION:
+      default:
+	exit(1);
+	/* ABORT(SSL_CANT_DO_CIPHER);	 */
+    }
+
+    EVP_DigestInit(&dgictx, md);
+    EVP_DigestUpdate(&dgictx, d->handshake_messages->data, d->handshake_messages->len);
+    EVP_DigestFinal(&dgictx, out, &len);
+    exit(0);
+  }
 #endif

--- a/ssl/ssldecode.h
+++ b/ssl/ssldecode.h
@@ -43,29 +43,12 @@
    ekr@rtfm.com  Thu Apr  1 15:02:02 1999
  */
 
-#include "ssl_rec.h"
+
 #ifndef _ssldecode_h
 #define _ssldecode_h
 
 #define CRDUMP(a,b,c) P_(P_CR) {Data d; d.data=b; d.len=c; exdump(ssl,a,&d); printf("\n");}
 #define CRDUMPD(a,b) P_(P_CR) {exdump(ssl,a,b);printf("\n");}
-
-struct ssl_decoder_ {
-     ssl_decode_ctx *ctx;
-     Data *session_id;
-     SSL_CipherSuite *cs;
-     Data *client_random;
-     Data *server_random;
-     int ephemeral_rsa;
-     Data *PMS;
-     Data *MS;
-     Data *handshake_messages;
-     int extended_master_secret;
-     ssl_rec_decoder *c_to_s;
-     ssl_rec_decoder *s_to_c;
-     ssl_rec_decoder *c_to_s_n;
-     ssl_rec_decoder *s_to_c_n;
-};
 
 int ssl_decode_ctx_create PROTO_LIST((ssl_decode_ctx **ctx,
   char *keyfile,char *password));

--- a/ssl/ssldecode.h
+++ b/ssl/ssldecode.h
@@ -67,7 +67,7 @@ int ssl_process_client_key_exchange PROTO_LIST((struct ssl_obj_ *,
 int ssl_process_change_cipher_spec PROTO_LIST((ssl_obj *ssl,
   ssl_decoder *d,int direction));
 int ssl_update_handshake_messages PROTO_LIST((ssl_obj *ssl,
-					      Data *data));
+  Data *data));
 int ssl_decode_record PROTO_LIST((ssl_obj *ssl,ssl_decoder *dec,int direction,
   int ct,int version,Data *d));
 

--- a/ssl/ssldecode.h
+++ b/ssl/ssldecode.h
@@ -66,7 +66,8 @@ int ssl_process_client_key_exchange PROTO_LIST((struct ssl_obj_ *,
   ssl_decoder *d,UCHAR *msg,int len));
 int ssl_process_change_cipher_spec PROTO_LIST((ssl_obj *ssl,
   ssl_decoder *d,int direction));
-
+int ssl_update_handshake_messages PROTO_LIST((ssl_obj *ssl,
+					      Data *data));
 int ssl_decode_record PROTO_LIST((ssl_obj *ssl,ssl_decoder *dec,int direction,
   int ct,int version,Data *d));
 

--- a/ssl/ssldecode.h
+++ b/ssl/ssldecode.h
@@ -43,12 +43,29 @@
    ekr@rtfm.com  Thu Apr  1 15:02:02 1999
  */
 
-
+#include "ssl_rec.h"
 #ifndef _ssldecode_h
 #define _ssldecode_h
 
 #define CRDUMP(a,b,c) P_(P_CR) {Data d; d.data=b; d.len=c; exdump(ssl,a,&d); printf("\n");}
 #define CRDUMPD(a,b) P_(P_CR) {exdump(ssl,a,b);printf("\n");}
+
+struct ssl_decoder_ {
+     ssl_decode_ctx *ctx;
+     Data *session_id;
+     SSL_CipherSuite *cs;
+     Data *client_random;
+     Data *server_random;
+     int ephemeral_rsa;
+     Data *PMS;
+     Data *MS;
+     Data *handshake_messages;
+     int extended_master_secret;
+     ssl_rec_decoder *c_to_s;
+     ssl_rec_decoder *s_to_c;
+     ssl_rec_decoder *c_to_s_n;
+     ssl_rec_decoder *s_to_c_n;
+};
 
 int ssl_decode_ctx_create PROTO_LIST((ssl_decode_ctx **ctx,
   char *keyfile,char *password));


### PR DESCRIPTION
This is intended to add support for TLS extensions. In addition to displaying the extensions as part of the output of the ClientHello and ServerHello handshake messages, this pull request adds additional support for the following extensions

1. Extended Master Secret and Session Hash [RFC 7627](https://tools.ietf.org/html/rfc7627)
2. Encrypt-then-MAC [RFC 7366](https://tools.ietf.org/html/rfc7366)
3. Server Name Indication [RFC 6066](https://tools.ietf.org/html/rfc6066#section-3)

Please let me know if you see any issues or would like me to make any additional modifications.