### PR TITLE
add support to decrypt resumed sessions

### DIFF
--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -202,6 +202,9 @@ static int decode_HandshakeType_ClientHello(ssl,dir,seg,data)
         exdump(ssl,"resume ",&session_id);
     }
 
+    ssl_process_client_session_id(ssl,ssl->decoder,session_id.data,
+      session_id.len);
+
     P_(P_HL){
 	SSL_DECODE_UINT16(ssl,"cipher Suites len",0,data,&cslen);
         explain(ssl,"cipher suites\n");

--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -325,7 +325,46 @@ int ssl_process_server_session_id(ssl,d,msg,len)
     return(0);
 #endif      
   }
-  
+
+int ssl_process_client_session_id(ssl,d,msg,len)
+  ssl_obj *ssl;
+  ssl_decoder *d;
+  UCHAR *msg;
+  int len;
+  {
+#ifdef OPENSSL    
+    int _status;
+    
+    /* First check if the client set session id */
+    //todo: check that session_id in decoder and msg are the same (and if not then take from msg?)
+    if(d->session_id)
+    {
+      /* Remove the master secret */
+      //todo: better save and destroy only when successfully read key log
+      r_data_destroy(&d->MS);
+
+      if(d->ctx->ssl_key_log_file && (ssl_read_key_log_file(d)==0) && d->MS)
+      {
+        //we found master secret for session in keylog
+        //try to save session
+        _status = ssl_save_session(ssl,d); 
+      }
+      else
+      {
+        //just return error 
+        _status = -1;
+      }
+    }
+    else
+    {
+      _status = -1;
+    }
+    return(_status);
+#else
+    return(0);
+#endif      
+  }
+
 int ssl_process_change_cipher_spec(ssl,d,direction)
   ssl_obj *ssl;
   ssl_decoder *d;

--- a/ssl/ssldecode.h
+++ b/ssl/ssldecode.h
@@ -62,6 +62,8 @@ int ssl_set_client_session_id PROTO_LIST((ssl_decoder *dp,
   UCHAR *msg,int len));
 int ssl_process_server_session_id PROTO_LIST((ssl_obj *obj,ssl_decoder *dp,
   UCHAR *msg,int len));
+int ssl_process_client_session_id PROTO_LIST((ssl_obj *obj,ssl_decoder *dp,
+  UCHAR *msg,int len));
 int ssl_process_client_key_exchange PROTO_LIST((struct ssl_obj_ *,
   ssl_decoder *d,UCHAR *msg,int len));
 int ssl_process_change_cipher_spec PROTO_LIST((ssl_obj *ssl,


### PR DESCRIPTION
now you can use NSS keylog to decrypt pcap with resumed sessions (i think must work for many ticket and every sessions id).