### PR TITLE
Fix multiple segfaults on out-of-bounds read access

### DIFF
--- a/base/network.c
+++ b/base/network.c
@@ -134,6 +134,12 @@ int network_process_packet(handler,timestamp,data,length)
     hlen=p.ip->ip_hl * 4;
     p.data += hlen;
     p.len = ntohs(p.ip->ip_len);
+
+    if(p.len > length) {
+        printf("Malformed packet, size from IP header is larger than size reported by libpcap, skipping ...\n");
+        return(0);
+    }
+
     if (p.len == 0) {
         DBG((0,"ip length reported as 0, presumed to be because of 'TCP segmentation offload' (TSO)\n"));
         p.len = p._len;

--- a/base/tcppack.c
+++ b/base/tcppack.c
@@ -242,7 +242,12 @@ static int process_data_segment(conn,handler,p,stream,direction)
     long l;
 
     l=p->len - p->tcp->th_off * 4;
-    
+
+    if(l < 0) {
+	printf("Malformed packet, computed TCP segment size is negative, skipping ...\n");
+	return(0);
+    }
+
     if(stream->close){
       DBG((0,"Rejecting packet received after FIN: %u:%u(%u)",
              ntohl(p->tcp->th_seq),ntohl(p->tcp->th_seq+l),l));

--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -240,7 +240,7 @@ static int decode_HandshakeType_ClientHello(ssl,dir,seg,data)
     	if (ssl_decode_switch(ssl,extension_decoder,ex,dir,seg,data) == R_NOT_FOUND) {
 	  decode_extension(ssl,dir,seg,data);
     	  P_(P_RH){
-    	    explain(ssl, "Extension type: %s not yet implemented in ssldump", ex);
+     	    explain(ssl, "Extension type: %u not yet implemented in ssldump\n", ex);
     	  }
     	  continue;
     	}
@@ -300,7 +300,7 @@ static int decode_HandshakeType_ServerHello(ssl,dir,seg,data)
     	if (ssl_decode_switch(ssl,extension_decoder,ex,dir,seg,data) == R_NOT_FOUND) {
 	  decode_extension(ssl,dir,seg,data);
     	  P_(P_RH){
-    	    explain(ssl, "Extension type: %s not yet implemented in ssldump", ex);
+    	    explain(ssl, "Extension type: %u not yet implemented in ssldump,\n", ex);
     	  }
     	  continue;
     	}
@@ -2538,7 +2538,7 @@ static int decode_extension_server_name(ssl,dir,seg,data)
 	if (ssl_decode_switch(ssl,server_name_type_decoder,t,dir,seg,data) == R_NOT_FOUND) {
 	  decode_server_name(ssl,dir,seg,data);
 	  P_(P_RH){
-	    explain(ssl, "Server Name type: %s not yet implemented in ssldump", t);
+	    explain(ssl, "Server Name type: %u not yet implemented in ssldump\n", t);
 	  }
 	  continue;
 	}


### PR DESCRIPTION
Fix multiple segfaults on out-of-bounds read access.
Tested with fuzzed pcap files, probably also reachable via live capture.
