### PR TITLE
Add parentheses around MAX and MIN

### DIFF
--- a/common/include/r_macros.h
+++ b/common/include/r_macros.h
@@ -76,11 +76,11 @@
 #define FREE(a) if(a) free(a)
 #endif
 #ifndef MIN
-#define MIN(a,b) ((a)>(b))?(b):(a)
+#define MIN(a,b) (((a)>(b))?(b):(a))
 #endif
 
 #ifndef MAX
-#define MAX(a,b) ((b)>(a))?(b):(a)
+#define MAX(a,b) (((b)>(a))?(b):(a))
 #endif
 
 #ifdef DEBUG


### PR DESCRIPTION
ssldecode.c:1101 MAX is used in expression and 0x40 is part of a in the macro

Example tls1.2 pcap and key not decrypting: [tlsv12.zip](https://github.com/adulau/ssldump/files/8761081/tlsv12.zip)

