### PR TITLE
Print MAC keys only for non AEAD ciphers

### DIFF
--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -1057,8 +1057,10 @@ static int ssl_generate_keying_material(ssl,d)
       }
     }
 
-    CRDUMP("Client MAC key",c_mk,ssl->cs->dig_len);
-    CRDUMP("Server MAC key",s_mk,ssl->cs->dig_len);    
+    if (!IS_AEAD_CIPHER(ssl->cs)){
+        CRDUMP("Client MAC key",c_mk,ssl->cs->dig_len);
+        CRDUMP("Server MAC key",s_mk,ssl->cs->dig_len);    
+    }
     CRDUMP("Client Write key",c_wk,ssl->cs->bits/8);
     CRDUMP("Server Write key",s_wk,ssl->cs->bits/8);    
 


### PR DESCRIPTION
c_mk and s_mk is only set for non aead ciphers at line 970 hence check before printing

<details>
<summary> Example seg fault </summary>

[out_tls12.zip](https://github.com/adulau/ssldump/files/8888745/out_tls12.zip)
```
 ./ssldump -S crypto -r out_tls12.pcap -l keys.txt
New TCP connection #1: localhost(44662) <-> localhost(4433)
1 1  0.0001 (0.0001)  C>S  Handshake
      ClientHello
        Version 3.3
        cipher suites
        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
        TLS_DHE_DSS_WITH_AES_256_GCM_SHA384
        TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
        TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
        TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8
        TLS_ECDHE_ECDSA_WITH_AES_256_CCM
        TLS_DHE_RSA_WITH_AES_256_CCM_8
        TLS_DHE_RSA_WITH_AES_256_CCM
        TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384
        TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384
        TLS_DHE_DSS_WITH_ARIA_256_GCM_SHA384
        TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384
        TLS_DH_anon_WITH_AES_256_GCM_SHA384
        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
        TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
        TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
        TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
        TLS_ECDHE_ECDSA_WITH_AES_128_CCM
        TLS_DHE_RSA_WITH_AES_128_CCM_8
        TLS_DHE_RSA_WITH_AES_128_CCM
        TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256
        TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256
        TLS_DHE_DSS_WITH_ARIA_128_GCM_SHA256
        TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256
        TLS_DH_anon_WITH_AES_128_GCM_SHA256
        TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
        TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
        TLS_DHE_DSS_WITH_AES_256_CBC_SHA256
        TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
        TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
        TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
        TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256
        TLS_DH_anon_WITH_AES_256_CBC_SHA256
        TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256
        TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
        TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
        TLS_DHE_DSS_WITH_AES_128_CBC_SHA256
        TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
        TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
        TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
        TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256
        TLS_DH_anon_WITH_AES_128_CBC_SHA256
        TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256
        TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
        TLS_DHE_RSA_WITH_AES_256_CBC_SHA
        TLS_DHE_DSS_WITH_AES_256_CBC_SHA
        TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
        TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA
        TLS_ECDH_anon_WITH_AES_256_CBC_SHA
        TLS_DH_anon_WITH_AES_256_CBC_SHA
        TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA
        TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
        TLS_DHE_RSA_WITH_AES_128_CBC_SHA
        TLS_DHE_DSS_WITH_AES_128_CBC_SHA
        TLS_DHE_RSA_WITH_SEED_CBC_SHA
        TLS_DHE_DSS_WITH_SEED_CBC_SHA
        TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
        TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA
        TLS_ECDH_anon_WITH_AES_128_CBC_SHA
        TLS_DH_anon_WITH_AES_128_CBC_SHA
        TLS_DH_anon_WITH_SEED_CBC_SHA
        TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA
        TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
        TLS_ECDHE_RSA_WITH_RC4_128_SHA
        TLS_ECDH_anon_WITH_RC4_128_SHA
        TLS_DH_anon_WITH_RC4_128_MD5
        TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
        TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
        TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
        TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA
        TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA
        TLS_DH_anon_WITH_3DES_EDE_CBC_SHA
        TLS_RSA_WITH_AES_256_GCM_SHA384
        TLS_RSA_WITH_AES_256_CCM_8
        TLS_RSA_WITH_AES_256_CCM
        TLS_RSA_WITH_ARIA_256_GCM_SHA384
        TLS_RSA_WITH_AES_128_GCM_SHA256
        TLS_RSA_WITH_AES_128_CCM_8
        TLS_RSA_WITH_AES_128_CCM
        TLS_RSA_WITH_ARIA_128_GCM_SHA256
        TLS_RSA_WITH_AES_256_CBC_SHA256
        TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
        TLS_RSA_WITH_AES_128_CBC_SHA256
        TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
        TLS_RSA_WITH_AES_256_CBC_SHA
        TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
        TLS_RSA_WITH_AES_128_CBC_SHA
        TLS_RSA_WITH_SEED_CBC_SHA
        TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
        TLS_RSA_WITH_RC4_128_SHA
        TLS_RSA_WITH_RC4_128_MD5
        TLS_RSA_WITH_3DES_EDE_CBC_SHA
        TLS_EMPTY_RENEGOTIATION_INFO_SCSV
        compression methods
                  NULL
        extensions
          server_name
              host_name: localhost
          ec_point_formats

          supported_groups

          session_ticket
          encrypt_then_mac
          extended_master_secret
          signature_algorithms
        ja3 string: 771,49196-49200-163-159-52393-52392-52394-49327-49325-49315-49311-49245-49249-49239-49235-167-49195-49199-162-158-49326-49324-49314-49310-49244-49248-49238-49234-166-49188-49192-107-106-49267-49271-196-195-109-197-49187-49191-103-64-49266-49270-190-189-108-191-49162-49172-57-56-136-135-49177-58-137-49161-49171-51-50-154-153-69-68-49176-52-155-70-49159-49169-49174-24-49160-49170-22-19-49175-27-157-49313-49309-49233-156-49312-49308-49232-61-192-60-186-53-132-47-150-65-5-4-10-255,0-11-10-35-22-23-13,29-23-30-25-24,0-1-2
        ja3 fingerprint: 85c00e5b282b35c87989a068904110ff
1 2  0.0029 (0.0027)  S>C  Handshake
      ServerHello
        Version 3.3
        session_id[0]=

        cipherSuite         TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
        compressionMethod                   NULL
        extensions
          renegotiation_info
          ec_point_formats
          session_ticket
          extended_master_secret
        ja3s string: 771,49196,65281-11-35-23
        ja3s fingerprint: abade5a4a7f42baf54766e5d108283b6
1 3  0.0029 (0.0000)  S>C  Handshake
      Certificate
1 4  0.0029 (0.0000)  S>C  Handshake
      ServerKeyExchange
Not enough data. Found 177 bytes (expecting 32767)
1 5    0.0029   (0.0000)    S>C    Handshake
        ServerHelloDone
1 6    0.0054   (0.0024)    C>S    Handshake
        ClientKeyExchange
          DiffieHellmanClientPublicValue[32]=
            62 10 be 0f 68 96 3e 56 87 93 04 23 c1 a2 37 a7
            80 60 9d 05 58 58 e4 4e 14 a3 91 ae 1d 93 36 05
          P_hash secret[48]=
            f9 d3 18 73 bb 72 36 b6 de 64 df 5c b5 33 2b 40
            a7 3e 7f 7a a0 ed 6f 90 4f 09 bd 0a cf a2 e0 57
            51 9c 0e 33 53 69 8e f8 dc 59 73 41 d4 20 3b bd

          P_hash seed[77]=
            6b 65 79 20 65 78 70 61 6e 73 69 6f 6e 07 61 1a
            a3 7d 06 11 59 b7 b0 1b f4 38 71 dc df 82 2b 0e
            61 37 c6 2d d5 ae 4c c0 81 88 81 d8 47 4c 75 40
            ab 66 ee b3 66 07 f4 5d 1b f3 95 56 fa 91 1b 2b
            89 87 e0 9a c4 70 ca 6a 6b b8 9c c0 67

          P_hash out[72]=
            fb 02 3f 66 27 40 7f f0 09 21 20 72 7c a5 be 71
            35 df 54 6c cc 46 f4 f5 76 1e 99 4b 9f e6 20 86
            86 c6 8e a3 7a d8 88 11 ff b5 21 c2 3b b4 92 cf
            84 53 e9 6b c5 29 7f 15 16 16 46 08 9e 7f 53 81
            51 d3 89 0c 5e d3 d1 e8

          PRF out[72]=
            fb 02 3f 66 27 40 7f f0 09 21 20 72 7c a5 be 71
            35 df 54 6c cc 46 f4 f5 76 1e 99 4b 9f e6 20 86
            86 c6 8e a3 7a d8 88 11 ff b5 21 c2 3b b4 92 cf
            84 53 e9 6b c5 29 7f 15 16 16 46 08 9e 7f 53 81
            51 d3 89 0c 5e d3 d1 e8

          Client MAC key[48]=
Segmentation fault (core dumped)

```
</details>


