### PR TITLE
Add CodeQL analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: ./autogen
+      - name: ./autogen.sh
         run: ./autogen.sh
       - name: Compiler version
         run: $CC -v

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,41 @@
+name: CodeQL analysis
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # build the main branch every Monday morning
+    - cron: '46 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+    - name: Build Application using script
+      run: |
+        ./autogen.sh
+        sudo apt-get install autoconf libtls-dev libpcap-dev libnet1-dev libjson-c-dev
+        ./configure
+        make
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ssldump - (de-facto repository gathering patches around the cyberspace)
 
 [![Build CI](https://github.com/adulau/ssldump/actions/workflows/build.yml/badge.svg)](https://github.com/adulau/ssldump/actions/workflows/build.yml)
+[![CodeQL analysis](https://github.com/adulau/ssldump/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/adulau/ssldump/actions/workflows/codeql-analysis.yml)
 
 # Release and tagging
 


### PR DESCRIPTION
- LGTM.com was shut down in December 2022 and recommended to use GitHub code scanning instead
- Possible results from CodeQL analysis will be listed at https://github.com/adulau/ssldump/security

See also: https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/