### PR TITLE
For Y2K38 on 32 bit systems `time_t tv_sec` can be `long long`

### DIFF
--- a/ssl/sslprint.c
+++ b/ssl/sslprint.c
@@ -714,26 +714,26 @@ int ssl_print_timestamp(ssl,ts)
     jobj = ssl->cur_json_st;
 
     if(jobj) {
-      snprintf(ts_str,40, "%ld%c%4.4ld",ts->tv_sec,'.',ts->tv_usec/100);
+      snprintf(ts_str,40, "%lld%c%4.4lld",(long long)ts->tv_sec,'.',(long long)ts->tv_usec/100);
       json_object *j_ts_str = json_object_new_string(ts_str);
       json_object_object_add(jobj, "timestamp", j_ts_str);
     }
     if(SSL_print_flags & SSL_PRINT_TIMESTAMP_ABSOLUTE) {
       if(!(SSL_print_flags & SSL_PRINT_JSON))
-        explain(ssl,"%d%c%4.4d ",ts->tv_sec,'.',ts->tv_usec/100);
+        explain(ssl,"%lld%c%4.4lld ",(long long)ts->tv_sec,'.',(long long)ts->tv_usec/100);
     }
     else{
       if((r=timestamp_diff(ts,&ssl->time_start,&dt)))
         ERETURN(r);
       if(!(SSL_print_flags & SSL_PRINT_JSON))
-        explain(ssl,"%d%c%4.4d ",dt.tv_sec,'.',dt.tv_usec/100);
+        explain(ssl,"%lld%c%4.4lld ",(long long)dt.tv_sec,'.',(long long)dt.tv_usec/100);
     }
     
     if((r=timestamp_diff(ts,&ssl->time_last,&dt))){
       ERETURN(r);
     }
     if(!(SSL_print_flags & SSL_PRINT_JSON))
-      explain(ssl,"(%d%c%4.4d)  ",dt.tv_sec,'.',dt.tv_usec/100);
+      explain(ssl,"(%lld%c%4.4lld)  ",(long long)dt.tv_sec,'.',(long long)dt.tv_usec/100);
 
     memcpy(&ssl->time_last,ts,sizeof(struct timeval));                
 


### PR DESCRIPTION
This should hopefully properly fix what CodeQL analysis spotted in #67. However, please review carefully!

I am not a C programmer or expert, but from my understanding, `time_t tv_sec` can be up to `long long`, e.g. on OpenBSD to cover Y2K38 compatibility on 32 bit systems. At https://man.openbsd.org/clock_gettime.2#EXAMPLES, there is an example, which this pull request is inspired from.

See also: https://lists.samba.org/archive/samba-technical/2015-September/109355.html