### PR TITLE
CI: libtls-dev → libssl-dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler }}
       - name: Install dependencies
-        run: sudo apt-get install autoconf libtls-dev libpcap-dev libnet1-dev libjson-c-dev
+        run: sudo apt install autoconf libssl-dev libpcap-dev libnet1-dev libjson-c-dev
       - name: ./configure
         run: ./configure
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build Application using script
       run: |
         ./autogen.sh
-        sudo apt-get install autoconf libtls-dev libpcap-dev libnet1-dev libjson-c-dev
+        sudo apt install autoconf libssl-dev libpcap-dev libnet1-dev libjson-c-dev
         ./configure
         make
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
With commit #66, I accidentially switched from libssl-dev to libtls-dev. However, ssldump depends on OpenSSL, which is libssl-dev. The libtls-dev package belongs to LibreTLS, which is a port of libtls from LibreSSL to OpenSSL (thus, in the end the correct dependency was installed indirectly, but let's do it right).