### PR TITLE
Fix typo, mention RHEL derivative

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ make
 (optional) make install
 ```
 
-On Fedora, Centos & RHEL:
+On Fedora, CentOS, RHEL & Rocky:
 ```
 dnf install autoconf automake gcc make openssl-devel libpcap-devel libnet-devel json-c-devel
 ./autogen.sh


### PR DESCRIPTION
Fix typo, mention RHEL derivative