### PR TITLE
Switch to gcc-12 (default: gcc-11), clang-14 is newest in ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [cc, clang, clang-13, gcc-10]
+        compiler: [cc, clang, gcc-12]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Use latest available compilers to catch possibly new build failures early.