### PR TITLE
Use correct cmake GNUInstallDirs variables with their built-in defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.13.4)
-include(CheckSymbolExists)
 
 project(
     ssldump
@@ -7,6 +6,9 @@ project(
     DESCRIPTION 20230814
     LANGUAGES C
 )
+
+include(CheckSymbolExists)
+include(GNUInstallDirs)
 
 configure_file(base/pcap-snoop.c.in base/pcap-snoop.c)
 
@@ -110,8 +112,5 @@ target_link_libraries(ssldump
         ${JSONC_LIBRARIES}
 )
 
-set(CMAKE_INSTALL_PREFIX "/usr/local")
-install(TARGETS ssldump DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-
-set(CMAKE_INSTALL_MANDIR "/usr/local/share/man")
+install(TARGETS ssldump DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ssldump.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)


### PR DESCRIPTION
Use correct cmake `GNUInstallDirs` variables with their built-in defaults. `GNUInstallDirs.cmake` expects that at least one language is enabled before including `GNUInstallDirs`.

See also: https://cmake.org/cmake/help/latest/command/install.html

My suggested changes, required to build `ssldump` successfully for Fedora and EPEL, are inspired from [baresip](https://github.com/baresip/baresip/blob/main/CMakeLists.txt) and [librsync](https://github.com/librsync/librsync/blob/master/CMakeLists.txt).