### PR TITLE
base: add support for "raw ip" captures

### DIFF
--- a/base/pcap-snoop.c.in
+++ b/base/pcap-snoop.c.in
@@ -205,6 +205,8 @@ void pcap_cb(u_char *ptr, const struct pcap_pkthdr *hdr, const u_char *data) {
 
   switch(pcap_if_type) {
     case DLT_RAW:
+      type = ETHERTYPE_IP;
+      break;
 #ifdef DLT_LOOP
     case DLT_LOOP:
 #endif


### PR DESCRIPTION
 - there is no need to deal with L2 as it's not even there