### PR TITLE
Implement compilation options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ option(DISABLE_OPTIMIZATION "Build without compiler optimizations" OFF)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
 if(DEBUG_BUILD)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb3 -DDEBUG")
+    add_definitions(-DDEBUG)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb3")
 endif()
 
 if(DISABLE_OPTIMIZATION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,22 @@ project(
     LANGUAGES C
 )
 
+######## User defined options
+option(DEBUG_BUILD "Build with debug facilities" OFF)
+option(DISABLE_OPTIMIZATION "Build without compiler optimizations" OFF)
+################
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+if(DEBUG_BUILD)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb3 -DDEBUG")
+endif()
+
+if(DISABLE_OPTIMIZATION)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+endif()
+
 include(CheckSymbolExists)
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Implement 2 cmake options:
    - `DEBUG_BUILD` adds `-ggdb3 -DDEBUG` to CFLAGS
    - `DISABLE_OPTIMIZATION` change optimization level from `-O2` to `-O0`.
 
Usage:
    `$ cmake -B build -G Ninja -DDEBUG_BUILD=ON -DDISABLE_OPTIMIZATION=ON`

*Note*: `-g` and `-02` compiler options are now used by default

This PR supersedes https://github.com/adulau/ssldump/pull/87
