### PR TITLE
Set packet type for RAW PCAPs

### DIFF
--- a/base/pcap-snoop.c.in
+++ b/base/pcap-snoop.c.in
@@ -205,6 +205,18 @@ void pcap_cb(u_char *ptr, const struct pcap_pkthdr *hdr, const u_char *data) {
 
   switch(pcap_if_type) {
     case DLT_RAW:
+      switch(((u_int8_t)*data) >> 4) {
+        case 4:
+          type = ETHERTYPE_IP;
+          break;
+        case 6:
+          type = ETHERTYPE_IPV6;
+          break;
+        default:
+          fprintf(stderr, "Unknown packet type, skipping ...\n");
+          return;
+      }
+      break;
 #ifdef DLT_LOOP
     case DLT_LOOP:
 #endif


### PR DESCRIPTION
This PR supersede https://github.com/adulau/ssldump/pull/88

It sets packet type to IPv4 or IPv6 based on first nibble of RAW packets (no L2 header).
