### PR TITLE
Fix problematic fdatasync() call on macOS

### DIFF
--- a/pcap/pcap_logger.c
+++ b/pcap/pcap_logger.c
@@ -54,7 +54,11 @@ static int init_pcap_logger(void *data) {
 }
 
 static int deinit_pcap_logger(void) {
-  fdatasync(pcap_fd);
+#if defined(_POSIX_SYNCHRONIZED_IO) && (_POSIX_SYNCHRONIZED_IO > 0)
+    fdatasync(pcap_fd);
+#else
+    fsync(pcap_fd);
+#endif
   close(pcap_fd);
   return 0;
 }


### PR DESCRIPTION
The fdatasync call generates a `implicit declaration of function 'fdatasync' is invalid in C99` warning when building for macOS (it's nowhere to be found in the system includes), but linking will eventually work fine because there is an unrelated syscall by the same name (different prototype), so it's not doing what it should. So lets not use it.