### PR TITLE
Original PCAP timestamps instead of timeofday-generated

### DIFF
--- a/pcap/logpkt.c
+++ b/pcap/logpkt.c
@@ -254,12 +254,16 @@ void logpkt_ctx_init(logpkt_ctx_t *ctx,
                      const struct sockaddr *src_addr,
                      socklen_t src_addr_len,
                      const struct sockaddr *dst_addr,
-                     socklen_t dst_addr_len) {
+                     socklen_t dst_addr_len,
+                     const uint32_t *timestamp_sec,
+                     const uint32_t *timestamp_usec) {
   ctx->libnet = libnet;
   memcpy(ctx->src_ether, src_ether, ETHER_ADDR_LEN);
   memcpy(ctx->dst_ether, dst_ether, ETHER_ADDR_LEN);
   memcpy(&ctx->src_addr, src_addr, src_addr_len);
   memcpy(&ctx->dst_addr, dst_addr, dst_addr_len);
+  memcpy(&ctx->timestamp_sec, timestamp_sec, sizeof(timestamp_sec));
+  memcpy(&ctx->timestamp_usec, timestamp_usec, sizeof(timestamp_usec));
   ctx->src_seq = 0;
   ctx->dst_seq = 0;
   if(mtu) {
@@ -275,13 +279,17 @@ void logpkt_ctx_init(logpkt_ctx_t *ctx,
  * Write the layer 2 frame contained in *pkt* to file descriptor *fd* already
  * open for writing.  First writes a PCAP record header, then the actual frame.
  */
-static int logpkt_pcap_write(const uint8_t *pkt, size_t pktsz, int fd) {
+static int logpkt_pcap_write(const uint8_t *pkt, size_t pktsz, int fd, uint32_t timestamp_sec, uint32_t timestamp_usec) {
   pcap_rec_hdr_t rec_hdr;
   struct timeval tv;
-
-  gettimeofday(&tv, NULL);
-  rec_hdr.ts_sec = tv.tv_sec;
-  rec_hdr.ts_usec = tv.tv_usec;
+  if (timestamp_sec != 0 || timestamp_usec != 0) {
+    rec_hdr.ts_sec = timestamp_sec;
+    rec_hdr.ts_usec = timestamp_usec;
+  } else {
+    gettimeofday(&tv, NULL);
+    rec_hdr.ts_sec = tv.tv_sec;
+    rec_hdr.ts_usec = tv.tv_usec;
+  }
   rec_hdr.orig_len = rec_hdr.incl_len = pktsz;
 
   if(write(fd, &rec_hdr, sizeof(rec_hdr)) != sizeof(rec_hdr)) {
@@ -488,7 +496,11 @@ static int logpkt_write_packet(logpkt_ctx_t *ctx,
                              CSA(&ctx->dst_addr), CSA(&ctx->src_addr), flags,
                              ctx->dst_seq, ctx->src_seq, payload, payloadlen);
     }
-    rv = logpkt_pcap_write(buf, sz, fd);
+    
+  fprintf(stderr,
+       "DEBUG --- timestamp in logpkt_write_packet: %d.%d\n", ctx->timestamp_sec, ctx->timestamp_usec);
+
+    rv = logpkt_pcap_write(buf, sz, fd, ctx->timestamp_sec, ctx->timestamp_usec);
     if(rv == -1) {
       printf("Error writing packet to PCAP file\n");
       return -1;

--- a/pcap/logpkt.c
+++ b/pcap/logpkt.c
@@ -496,9 +496,6 @@ static int logpkt_write_packet(logpkt_ctx_t *ctx,
                              CSA(&ctx->dst_addr), CSA(&ctx->src_addr), flags,
                              ctx->dst_seq, ctx->src_seq, payload, payloadlen);
     }
-    
-  fprintf(stderr,
-       "DEBUG --- timestamp in logpkt_write_packet: %d.%d\n", ctx->timestamp_sec, ctx->timestamp_usec);
 
     rv = logpkt_pcap_write(buf, sz, fd, ctx->timestamp_sec, ctx->timestamp_usec);
     if(rv == -1) {

--- a/pcap/logpkt.h
+++ b/pcap/logpkt.h
@@ -51,6 +51,8 @@ typedef struct {
   uint32_t src_seq;
   uint32_t dst_seq;
   size_t mss;
+  uint32_t timestamp_sec;
+  uint32_t timestamp_usec;
 } logpkt_ctx_t;
 
 #define LOGPKT_REQUEST 0
@@ -65,7 +67,9 @@ void logpkt_ctx_init(logpkt_ctx_t *,
                      const struct sockaddr *,
                      socklen_t,
                      const struct sockaddr *,
-                     socklen_t);
+                     socklen_t,
+                     const uint32_t *,
+                     const uint32_t *);
 int logpkt_write_payload(logpkt_ctx_t *,
                          int,
                          int,

--- a/pcap/pcap_logger.c
+++ b/pcap/pcap_logger.c
@@ -72,6 +72,10 @@ static int create_pcap_logger(proto_obj **objp,
   int _status;
   logpkt_ctx_t *pcap_obj = 0;
   struct sockaddr_in src_addr, dst_addr;
+  uint32_t timestamp_sec, timestamp_usec;
+
+  timestamp_sec = base_time->tv_sec;
+  timestamp_usec = base_time->tv_usec;
 
   if(!(pcap_obj = (logpkt_ctx_t *)calloc(1, sizeof(logpkt_ctx_t))))
     ABORT(R_NO_MEMORY);
@@ -89,7 +93,9 @@ static int create_pcap_logger(proto_obj **objp,
   logpkt_ctx_init(pcap_obj, NULL, 0, content_pcap_src_ether,
                   content_pcap_dst_ether, (const struct sockaddr *)&src_addr,
                   sizeof(src_addr), (const struct sockaddr *)&dst_addr,
-                  sizeof(dst_addr));
+                  sizeof(dst_addr),
+                  &timestamp_sec,
+                  &timestamp_usec);
   *objp = (proto_obj *)pcap_obj;
   _status = 0;
 abort:


### PR DESCRIPTION
I suggest to change PCAP logger code cause of bad timestamps. Timeofday-generated timestamps are not so good for zeek or any dpi parsing (the packages are not in the right order). Also original timestamps seems to be better in PCAP cause it helps to see the real time of the package (for example in Wireshark).

For example on one malware traffic (Smert Ransomware):
PCAP source: https://app.any.run/tasks/5b2f8a32-62ea-47b1-9c3a-b9b474fb0774/
Original pcap timestamps (Wireshark with SSLKeyLogFile specified in settings):


![image](https://github.com/user-attachments/assets/eaa0ec4f-b5eb-4cca-a4d1-e403da86a271)

Current ssldump version (gettimeofday-generated timestamps - decrypted at 7 Aug):
![image](https://github.com/user-attachments/assets/4a71e128-26fe-4344-bf86-03986500f7f8)

This PR's version:
![image](https://github.com/user-attachments/assets/8843856b-2c6b-4787-a335-bb9c742fcbf6)

This feature may be very helpful for some malware traffic analysts in future and seems to be more correctly. Please correct me if I'm wrong somewhere.