### PR TITLE
TLSv1.3 garbage in flow fix and segmentation fault fix

### DIFF
--- a/ssl/sslprint.c
+++ b/ssl/sslprint.c
@@ -288,13 +288,17 @@ int ssl_expand_record(ssl_obj *ssl,
     // try to save unencrypted data to logger
     // we must save record with type "application_data" (this is unencrypted
     // data)
+    if(ssl->version == TLSV13_VERSION) {
+      ct = d.data[--d.len];  // In TLS 1.3 ct is stored in the end for encrypted records
+      if(ct == 23) {
+        if(logger) {
+          logger->vtbl->data(ssl->logger_obj, d.data, d.len, direction);
+        }
+      }
+    }
     if(ct == 23) {
       if(logger) {
         logger->vtbl->data(ssl->logger_obj, d.data, d.len, direction);
-      }
-      if(ssl->version == TLSV13_VERSION) {
-        ct = d.data[--d.len];  // In TLS 1.3 ct is stored in the end for
-                               // encrypted records
       }
     }
     if((r = ssl_decode_switch(ssl, ContentType_decoder, ct, direction, q,

--- a/ssl/sslprint.c
+++ b/ssl/sslprint.c
@@ -296,9 +296,11 @@ int ssl_expand_record(ssl_obj *ssl,
         }
       }
     }
-    if(ct == 23) {
-      if(logger) {
-        logger->vtbl->data(ssl->logger_obj, d.data, d.len, direction);
+    else {
+      if(ct == 23) {
+        if(logger) {
+          logger->vtbl->data(ssl->logger_obj, d.data, d.len, direction);
+        }
       }
     }
     if((r = ssl_decode_switch(ssl, ContentType_decoder, ct, direction, q,


### PR DESCRIPTION
Hi! I suggest to change:
1) ssldecode code because of segmentation fault on this one pcap:
https://app.any.run/tasks/90ff9de3-440f-4f5a-8f01-edd8d219def8
![image-1](https://github.com/user-attachments/assets/f7d8d5a5-a051-4d26-8ac6-edbe960bf767)
2) sslprint code because of TLSv1.3 garbage in flow after decryption (TLS and decrypted traffic mix). This problem is caused by possible bug of ct getting. Maybe @lord8266 will correct me.
https://app.any.run/tasks/db11da7d-817c-4364-a15a-38011f8e5129
![image1](https://github.com/user-attachments/assets/db5878bc-5a9f-4c03-ad42-93e71c3c1bbc)


Changes:
1) Cause of segfault in ssldecode
![image2](https://github.com/user-attachments/assets/88b38eea-7c76-47c3-b96d-c1a95a2ec81d)
Resolved:
![image3](https://github.com/user-attachments/assets/3759fa0c-896b-4fb7-a4bd-fc7cd7c976c0)
2) After decryption TCP stream now not have unnecessary data (like TLS and SSL certificates and bytes that are not related to the original decrypted information):
![image9](https://github.com/user-attachments/assets/9a856efa-b7d6-4a14-8cbd-5783dc32dcb7)

I tested these changes on many pcaps and these problems no longer appeared.