### PR TITLE
Harden TLS parsing bounds checks and secure OpenSSL password callback

### DIFF
--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -1438,6 +1438,12 @@ static int decode_extension_server_name(ssl_obj *ssl,
       l -= (p - data->len);
     }
   } else {
+    if(l > data->len) {
+      fprintf(stderr,
+              "Error: short server_name extension: expected %u got %u\n", l,
+              data->len);
+      ERETURN(R_EOD);
+    }
     data->len -= l;
     data->data += l;
   }
@@ -1453,6 +1459,12 @@ static int decode_extension_encrypt_then_mac(ssl_obj *ssl,
   etm = &ssl->extensions->encrypt_then_mac;
 
   SSL_DECODE_UINT16(ssl, "extension length", 0, data, &l);
+  if(l > data->len) {
+    fprintf(stderr,
+            "Error: short encrypt_then_mac extension: expected %u got %u\n", l,
+            data->len);
+    ERETURN(R_EOD);
+  }
   data->len -= l;
   data->data += l;
 
@@ -1469,6 +1481,13 @@ static int decode_extension_extended_master_secret(ssl_obj *ssl,
   ems = &ssl->extensions->extended_master_secret;
 
   SSL_DECODE_UINT16(ssl, "extension length", 0, data, &l);
+  if(l > data->len) {
+    fprintf(
+        stderr,
+        "Error: short extended_master_secret extension: expected %u got %u\n",
+        l, data->len);
+    ERETURN(R_EOD);
+  }
   data->len -= l;
   data->data += l;
 
@@ -1479,6 +1498,11 @@ static int decode_extension(ssl_obj *ssl, int dir, segment *seg, Data *data) {
   int r;
   UINT4 l;
   SSL_DECODE_UINT16(ssl, "extension length", 0, data, &l);
+  if(l > data->len) {
+    fprintf(stderr, "Error: short extension data: expected %u got %u\n", l,
+            data->len);
+    ERETURN(R_EOD);
+  }
   data->len -= l;
   data->data += l;
   return 0;
@@ -1519,6 +1543,12 @@ static int decode_extension_supported_groups(ssl_obj *ssl,
     if(ja3_ec_str && ja3_ec_str[strlen(ja3_ec_str) - 1] == '-')
       ja3_ec_str[strlen(ja3_ec_str) - 1] = '\0';
   } else {
+    if(l > data->len) {
+      fprintf(stderr,
+              "Error: short supported_groups extension: expected %u got %u\n",
+              l, data->len);
+      ERETURN(R_EOD);
+    }
     data->len -= l;
     data->data += l;
   }
@@ -1569,6 +1599,12 @@ static int decode_extension_ec_point_formats(ssl_obj *ssl,
     if(ja3_ecp_str && ja3_ecp_str[strlen(ja3_ecp_str) - 1] == '-')
       ja3_ecp_str[strlen(ja3_ecp_str) - 1] = '\0';
   } else {
+    if(l > data->len) {
+      fprintf(stderr,
+              "Error: short ec_point_formats extension: expected %u got %u\n",
+              l, data->len);
+      ERETURN(R_EOD);
+    }
     data->len -= l;
     data->data += l;
   }
@@ -1725,6 +1761,11 @@ static int decode_server_name_type_host_name(ssl_obj *ssl,
   int r;
   UINT4 l;
   SSL_DECODE_UINT16(ssl, "server name length", 0, data, &l);
+  if(l > data->len) {
+    fprintf(stderr, "Error: short server name: expected %u got %u\n", l,
+            data->len);
+    ERETURN(R_EOD);
+  }
   if(!(NET_print_flags & NET_PRINT_JSON))
     printf(": %.*s", l, data->data);
 
@@ -1735,8 +1776,6 @@ static int decode_server_name_type_host_name(ssl_obj *ssl,
     if(server_name != NULL) {
       if(ssl->server_name)
         free(ssl->server_name);
-      if(l > data->len)
-        l = data->len;
       memcpy(server_name, data->data, l);
       ssl->server_name = server_name;
     }
@@ -1750,6 +1789,11 @@ static int decode_server_name(ssl_obj *ssl, int dir, segment *seg, Data *data) {
   int r;
   UINT4 l;
   SSL_DECODE_UINT16(ssl, "server name length", 0, data, &l);
+  if(l > data->len) {
+    fprintf(stderr, "Error: short server name: expected %u got %u\n", l,
+            data->len);
+    ERETURN(R_EOD);
+  }
   data->len -= l;
   data->data += l;
   return 0;

--- a/ssl/ssldecode.c
+++ b/ssl/ssldecode.c
@@ -143,11 +143,17 @@ int ssl_restore_session PROTO_LIST((ssl_obj * ssl, ssl_decoder *d));
 
 /*The password code is not thread safe*/
 static int password_cb(char *buf, int num, int rwflag, void *userdata) {
-  if(num < strlen(ssl_password) + 1)
+  size_t password_len;
+
+  if(!ssl_password || num <= 0)
     return 0;
 
-  strcpy(buf, ssl_password);
-  return strlen(ssl_password);
+  password_len = strlen(ssl_password);
+  if(password_len >= (size_t)num)
+    return 0;
+
+  memcpy(buf, ssl_password, password_len + 1);
+  return (int)password_len;
 }
 
 int ssl_decode_ctx_create(ssl_decode_ctx **dp,


### PR DESCRIPTION
### Motivation
- Protect TLS parsing paths from malformed or truncated input that could cause out-of-bounds reads or parser desynchronization.
- Prevent unsafe string operations in the OpenSSL password callback that can read or write out of bounds.

### Description
- Added explicit bounds checks before skipping extension payloads in `ssl/ssl.enums.c` to fail closed when advertised extension lengths exceed available data, returning `R_EOD` on error.
- Validated SNI (server name) lengths in `decode_server_name_type_host_name()` and `decode_server_name()` to avoid printing or copying past the buffer and to reject truncated names.
- Hardened `password_cb` in `ssl/ssldecode.c` by checking `ssl_password` and `num`, computing `strlen` once, preventing overflow, replacing `strcpy` with a bounded `memcpy`, and returning an appropriately cast length.
- Changes are localized to `ssl/ssl.enums.c` and `ssl/ssldecode.c` and aim to make parsing of untrusted TLS records safer and password handling more robust.

### Testing
- Ran the project configuration/build script via `./build.sh`; configuration proceeded until dependency detection but the build aborted because `libpcap` development headers were not present on this environment, so a full build could not be completed (failure due to missing `libpcap-dev`).
- Performed local static inspections of the modified functions and ran basic repository searches to confirm the updated patterns and no obvious new uses of unsafe copies; no automated unit tests were present or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2240612083248983788836b3332c)