### PR TITLE
Fix TCP reassembly queue ordering/consumption and tighten idle expiry

### DIFF
--- a/base/tcpconn.c
+++ b/base/tcpconn.c
@@ -169,7 +169,7 @@ int clean_old_conn(void) {
     conn = conn->next;
     if(timestamp_diff(&last_packet_seen_time, &tcpconn->last_seen_time, &dt))
       continue;
-    if(dt.tv_sec > conn_ttl) {
+    if(dt.tv_sec >= conn_ttl) {
       i++;
       tcp_destroy_conn(tcpconn);
     }

--- a/base/tcppack.c
+++ b/base/tcppack.c
@@ -226,7 +226,7 @@ static int process_data_segment(tcp_conn *conn,
   int r, _status;
   tcp_seq seq, right_edge;
   segment _seg;
-  segment *seg, *nseg = 0;
+  segment *seg, *nseg = 0, *prev = 0;
   long l;
 
   l = p->len - p->tcp->th_off * 4;
@@ -284,9 +284,10 @@ static int process_data_segment(tcp_conn *conn,
     /* Out of order segment */
     tcp_seq left_edge;
 
-    for(seg = 0; seg; seg = seg ? seg->next : stream->oo_queue) {
-      if(seg->next->s_seq > seq)
+    for(seg = stream->oo_queue; seg; seg = seg->next) {
+      if(!SEQ_LT(seg->s_seq, seq))
         break;
+      prev = seg;
     }
 
     if(!(nseg = (segment *)calloc(1, sizeof(segment))))
@@ -296,20 +297,20 @@ static int process_data_segment(tcp_conn *conn,
     nseg->s_seq = seq;
 
     /*Insert this segment into the reassembly queue*/
-    if(seg) {
-      nseg->next = seg->next;
-      seg->next = nseg;
+    if(prev) {
+      nseg->next = prev->next;
+      prev->next = nseg;
     } else {
       nseg->next = stream->oo_queue;
       stream->oo_queue = nseg;
     }
 
-    left_edge = seg ? seg->s_seq : stream->seq;
+    left_edge = prev ? prev->s_seq : stream->seq;
     STRIM(left_edge, nseg);
   } else {
     /*First segment -- just thread the unallocated data on the
      list so we can pass to the analyzer*/
-    _seg.next = 0;
+    _seg.next = stream->oo_queue;
     _seg.p = p;
     _seg.s_seq = seq;
 
@@ -331,7 +332,7 @@ static int process_data_segment(tcp_conn *conn,
       } else {
         for(seg = &_seg; seg->next; seg = seg->next) {
           if(seg->p->tcp->th_flags & (TH_FIN)) {
-            stream->close = _seg.p->tcp->th_flags & (TH_FIN);
+            stream->close = seg->p->tcp->th_flags & (TH_FIN);
             break;
           }
           if(seg->len + seg->s_seq != seg->next->s_seq)
@@ -350,7 +351,6 @@ static int process_data_segment(tcp_conn *conn,
           conn->state = TCP_STATE_CLOSED;
       }
 
-      free_tcp_segment_queue(stream->oo_queue);
       stream->oo_queue = seg->next;
       seg->next = 0;
       stream->seq = seg->s_seq + seg->len;


### PR DESCRIPTION
### Motivation

- Ensure correct TCP flow reassembly when packets arrive out-of-order and avoid dropping or losing queued data during in-order delivery. 
- Make idle connection eviction behavior deterministic at the configured TTL boundary.
- Align behavior with common IDS reassembly best-practices (ordered buffering, only delivering contiguous data, preserving tails). 

### Description

- Fix out-of-order insertion in `process_data_segment` by traversing the `stream->oo_queue` with a `prev` pointer and inserting the new `segment` after `prev` to preserve sequence order (`base/tcppack.c`).
- Use the correct left-edge source when trimming newly-inserted segments (`left_edge = prev ? prev->s_seq : stream->seq`) and call `STRIM` accordingly (`base/tcppack.c`).
- Chain the incoming in-order `_seg` onto the existing out-of-order queue by setting `_seg.next = stream->oo_queue` so queued segments can be consumed once gaps are filled (`base/tcppack.c`).
- Detect `FIN` using the current `seg` during chain iteration instead of always reading `_seg`, fixing close-state transitions (`base/tcppack.c`).
- Stop unconditionally freeing the entire `stream->oo_queue` during in-order processing and instead advance `stream->oo_queue = seg->next` so the remaining tail is preserved for later packets (`base/tcppack.c`).
- Tighten the idle expiration condition in `clean_old_conn` from `dt.tv_sec > conn_ttl` to `dt.tv_sec >= conn_ttl` for deterministic eviction when age equals TTL (`base/tcpconn.c`).

### Testing

- Attempted a full build with `./build.sh`; configuration failed because the environment is missing the `libpcap` development files (CMake reported `Unable to find libpcap development files`), so a complete compile/test run could not be performed.
- Verified source edits by committing the changes and inspecting diffs; no unit tests were present or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de249463208324a5b79e8c5c45c359)