### PR TITLE
Neutralize ANSI control chars in JSON msg_data field

### DIFF
--- a/ssl/ssl.enums.c
+++ b/ssl/ssl.enums.c
@@ -114,7 +114,7 @@ static int decode_ContentType_application_data(ssl_obj *ssl,
                                                int dir,
                                                segment *seg,
                                                Data *data) {
-  int r;
+  int r,i;
   Data d;
   struct json_object *jobj;
   jobj = ssl->cur_json_st;
@@ -124,6 +124,11 @@ static int decode_ContentType_application_data(ssl_obj *ssl,
   SSL_DECODE_OPAQUE_ARRAY(ssl, "data", data->len, 0, data, &d);
 
   if(NET_print_flags & NET_PRINT_JSON) {
+	for(i=0; i<d.len; i++) {
+		if((unsigned char) d.data[i] & 0x80 || (unsigned char) d.data[i] < 0x20) {
+			d.data[i] = '.';
+		}
+	}
     json_object_object_add(jobj, "msg_data",
                            json_object_new_string_len((char *)d.data, d.len));
   } else


### PR DESCRIPTION
Chars with hex value < 0x20 and > 0x7F are now replaced by '.' in msg_data field.
Example:
{
  "connection_number": 39,
  "record_count": 136,
  "timestamp": "1776287456.9107",
  "src_name": "csp-reporting.cloudflare.com",
  "src_ip": "104.18.21.157",
  "src_port": 443,
  "dst_name": "10.137.0.17",
  "dst_ip": "10.137.0.17",
  "dst_port": 45784,
  "record_len": 289,
  "record_ver": "3.4",
  "msg_type": "application data",
  "msg_data": "..J.Qo....../@..S.h.i4.8....PU..,O.hU73.F.6v....r.h...~.....w... ..S.=............6m.%...o.9|...f......(.r.Bs..-5(........Z.T.....8C..../.0.......h_...........<@..&04.....c..%V..<..#g9..+.0...V.........5\"...p.?.........\\..JZ../.........3...q;..VB...f....U+........@..{......q.mx6..?.Ks.b"
}
